### PR TITLE
platformdirs 2.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "platformdirs" %}
-{% set version = "2.4.0" %}
+{% set version = "2.5.2" %}
 
 
 package:
@@ -8,23 +8,21 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/platformdirs-{{ version }}.tar.gz
-  sha256: 367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2
+  sha256: 58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools >=44
-    - setuptools-scm >=5
-    - toml
-    - wheel >=0.30
+    - hatchling >=0.22.0
+    - hatch-vcs
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -33,7 +31,6 @@ test:
     - pip check
   requires:
     - pip
-    - python <3.10
 
 about:
   home: https://github.com/platformdirs/platformdirs
@@ -43,6 +40,7 @@ about:
   summary: A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".
   dev_url: https://github.com/platformdirs/platformdirs
   doc_url: https://platformdirs.readthedocs.io/
+  doc_source_url: https://github.com/platformdirs/platformdirs/tree/main/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/platformdirs/platformdirs/blob/2.5.2/CHANGES.rst
License: https://github.com/platformdirs/platformdirs/blob/2.5.2/LICENSE.txt
Requirements: https://github.com/platformdirs/platformdirs/blob/2.5.2/pyproject.toml

Actions:
1. Remove `noarch`
2. Skip `py<37`
3. Add `hatchling` backend in host
4. Fix `python`
5. Add `doc_source_url`