### PR TITLE
Update to v 3.8.1:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     - pip
     - hatchling 1.18.0
     - hatch-vcs 0.3.0
-    - setuptools
-    - wheel
   run:
     - python
     - typing-extensions >=4.6.3  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "platformdirs" %}
-{% set version = "2.5.2" %}
+{% set version = "3.8.1" %}
 
 
 package:
@@ -7,41 +7,49 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/platformdirs-{{ version }}.tar.gz
-  sha256: 58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f87ca4fcff7d2b0f81c6a748a77973d7af0f4d526f98f308477c3c436c74d528
 
 build:
   number: 0
-  # Trigger 1
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - hatchling >=0.22.0
-    - hatch-vcs
+    - hatchling 1.18.0
+    - hatch-vcs 0.3.0
+    - setuptools
+    - wheel
   run:
     - python
+    - typing-extensions >=4.6.3  # [py<38]
 
 test:
+  source_files:
+    - tests
   imports:
     - platformdirs
   commands:
     - pip check
+    - pytest tests -vv
   requires:
     - pip
+    - pytest
+    - pytest-mock
+    - appdirs
 
 about:
   home: https://github.com/platformdirs/platformdirs
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".
+  description: A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".
   dev_url: https://github.com/platformdirs/platformdirs
   doc_url: https://platformdirs.readthedocs.io/
-  doc_source_url: https://github.com/platformdirs/platformdirs/tree/main/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Upstream: https://github.com/platformdirs/platformdirs 
Jira: [PKG-2619]

 - snowflake-connector-python requires platformdirs >=2.6.0,<3.9.0, hence not the latest version is built, but 3.8.1
 - Very minor changes, the major one being addition of pytest tests to the recipe. Also, dependency versions have been updated as required.
 - Added typing-extensions >=4.6.3  # [py<38] to run section just for the sake of recipe completeness.

[PKG-2619]: https://anaconda.atlassian.net/browse/PKG-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ