### PR TITLE
platformdirs 2.5.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,25 @@
 {% set name = "platformdirs" %}
-{% set version = "4.3.7" %}
+{% set version = "2.5.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
 
 build:
   number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<39]
 
 requirements:
   host:
     - python
     - pip
-    - hatchling >=1.27
-    - hatch-vcs >=0.4
+    - hatchling >=0.22.0
+    - hatch-vcs
   run:
     - python
 
@@ -28,20 +28,20 @@ test:
     - tests
   imports:
     - platformdirs
-  commands:
-    - pip check
-    - pytest tests -vv
   requires:
     - pip
     - pytest
     - pytest-mock
     - appdirs
+  commands:
+    - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/platformdirs/platformdirs
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: LICENSE.txt
   description: |
     About A small Python module for determining appropriate
     platform-specific dirs, e.g. a "user data dir".


### PR DESCRIPTION
platformdirs 2.5.2 

**Destination channel:** default

### Links

- [PKG-9715]
- dev_url:        https://github.com/platformdirs/platformdirs/tree/2.5.2
- conda_forge:    https://github.com/conda-forge/platformdirs-feedstock
- pypi:           https://pypi.org/project/platformdirs/2.5.2
- pypi inspector: https://inspector.pypi.io/project/platformdirs/2.5.2

### Explanation of changes:

- new version number


[PKG-9715]: https://anaconda.atlassian.net/browse/PKG-9715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ